### PR TITLE
Move @tamagui/core from dependencies to peerDepenedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "generate": "node ./bin/build"
   },
   "dependencies": {
-    "@tamagui/core": "^1.0.4"
+
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-native-svg": ">=12"
+    "react-native-svg": ">=12",
+    "@tamagui/core": ">=1"
   },
   "importSort": {
     ".js, .jsx, .ts, .tsx": {
@@ -33,6 +34,7 @@
     }
   },
   "devDependencies": {
+    "@tamagui/core": "^1.0.4",
     "@types/react": "^18.0.26",
     "@types/react-dom": "18.0.9",
     "@tamagui/build": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "prettier-fix": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "generate": "node ./bin/build"
   },
-  "dependencies": {
-
-  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",


### PR DESCRIPTION
Due to the frequent updates from Tamagui I suggest to move `@tamagui/core` to peerDependency. In my monorepo setup it seems that a different version of `@tamagui/core` is requested from `tamagui-phosphor-icons` which could lead to context mismatch.